### PR TITLE
Fix SQL Server null parameters and bump version to 1.0.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+When bumping the package version, check git history for the last change to `<VersionPrefix>` to determine what behavior has changed since the last package version bump. Use that information to decide whether to use a minor bump or a patch bump. Update `Directory.Build.props`, but set `<PackageValidationBaselineVersion>` to the current value of `<VersionPrefix>` before bumping `<VersionPrefix>`. Then update `ReleaseNotes.md`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);1591;1998;CA1510;CA1513;IDE0300;NU1507</NoWarn>
+    <NoWarn>$(NoWarn);1591;1998;CA1510;CA1513;IDE0300;IDE0370;NU1507</NoWarn>
     <NeutralLanguage>en-US</NeutralLanguage>
     <DebugType>embedded</DebugType>
     <GitHubOrganization>MuchAdoNet</GitHubOrganization>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageValidationBaselineVersion>0.0.0</PackageValidationBaselineVersion>
+    <VersionPrefix>1.1.0</VersionPrefix>
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 1.1.0
+
+* Add SQLite batch command support.
+* Add retry and transaction retry APIs, including the `MuchAdo.Polly` package.
+* Improve nullable type and null parameter handling across providers, including Sqlite and SqlServer.
+* Add .NET 10 targets and update the codebase to C# 14.
+
 ## 1.0.0
 
 * Initial release. Adapted from [Faithlife.Data](https://github.com/Faithlife/FaithlifeData/) and [Faithlife.Reflection](https://github.com/Faithlife/FaithlifeReflection/).

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,11 +1,9 @@
 # Release Notes
 
-## 1.1.0
+## 1.0.1
 
-* Add SQLite batch command support.
-* Add retry and transaction retry APIs, including the `MuchAdo.Polly` package.
-* Improve nullable type and null parameter handling across providers, including Sqlite and SqlServer.
-* Add .NET 10 targets and update the codebase to C# 14.
+* Add .NET 10 targets.
+* Fix SQL Server null parameter handling.
 
 ## 1.0.0
 

--- a/src/MuchAdo.SqlServer/SqlServerDbConnector.cs
+++ b/src/MuchAdo.SqlServer/SqlServerDbConnector.cs
@@ -42,5 +42,5 @@ public class SqlServerDbConnector : DbConnector
 		static async ValueTask<SqlConnection> DoAsync(ValueTask<IDbConnection> t) => (SqlConnection) await t.ConfigureAwait(false);
 	}
 
-	protected override IDataParameter CreateParameterCore<T>(string name, T value) => new SqlParameter(name, value);
+	protected override IDataParameter CreateParameterCore<T>(string name, T value) => new SqlParameter(name, value is null ? DBNull.Value : value);
 }

--- a/tests/MuchAdo.SqlServer.Tests/SqlServerTests.cs
+++ b/tests/MuchAdo.SqlServer.Tests/SqlServerTests.cs
@@ -50,9 +50,8 @@ internal sealed class SqlServerTests
 			.Should().Be(1);
 	}
 
-	private static DbConnector CreateConnector() => new(
-		new SqlConnection("data source=localhost;user id=sa;password=P@ssw0rd;initial catalog=test;TrustServerCertificate=True"),
-		new DbConnectorSettings { SqlSyntax = SqlSyntax.SqlServer });
+	private static SqlServerDbConnector CreateConnector() => new(
+		new SqlConnection("data source=localhost;user id=sa;password=P@ssw0rd;initial catalog=test;TrustServerCertificate=True"));
 
 #if NET
 	private const string c_suffix = "_netc";


### PR DESCRIPTION
This PR fixes the current SQL Server null-parameter work and updates package metadata for the next release.

- fix SQL Server connector handling for null parameters
- keep the SQL Server test connector aligned with that behavior
- bump the package version to 1.0.1
- set the package validation baseline to 1.0.0 and add 1.0.1 release notes
