### PR TITLE
Use provider connection types in connector constructors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <PackageValidationBaselineVersion>1.1.0</PackageValidationBaselineVersion>
+    <VersionPrefix>1.2.0</VersionPrefix>
+    <PackageValidationBaselineVersion>1.2.0</PackageValidationBaselineVersion>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,8 +1,12 @@
 # Release Notes
 
+## 1.2.0
+
+* Change platform-specific connector constructors to require their provider-specific connection types instead of `DbConnection`. (This is a breaking change, but we're sticking with a minor version bump due to limited impact.)
+
 ## 1.1.0
 
-* Change type of `Sql.Empty` from `SqlParamSource` to `SqlSource` so that it works better with `var`. (This is, strictly speaking, a breaking change, but there is too little actual impact to bump the major version. )
+* Change type of `Sql.Empty` from `SqlParamSource` to `SqlSource` so that it works better with `var`. (This is, strictly speaking, a breaking change, but there is too little actual impact to bump the major version.)
 * Introduce `Sql.NoParams` for an empty `SqlParamSource`.
 
 ## 1.0.1

--- a/src/MuchAdo.MySql/MySqlDbConnector.cs
+++ b/src/MuchAdo.MySql/MySqlDbConnector.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.Data.Common;
 using MySqlConnector;
 
 namespace MuchAdo.MySql;
@@ -9,16 +8,14 @@ namespace MuchAdo.MySql;
 /// </summary>
 public class MySqlDbConnector : DbConnector
 {
-	public MySqlDbConnector(DbConnection connection)
+	public MySqlDbConnector(MySqlConnection connection)
 		: this(connection, MySqlDbConnectorSettings.Default)
 	{
 	}
 
-	public MySqlDbConnector(DbConnection connection, MySqlDbConnectorSettings settings)
+	public MySqlDbConnector(MySqlConnection connection, MySqlDbConnectorSettings settings)
 		: base(connection, settings)
 	{
-		if (connection is not MySqlConnection)
-			throw new ArgumentException("The connection must be a MySqlConnection.", nameof(connection));
 	}
 
 	public new MySqlConnection Connection => (MySqlConnection) base.Connection;

--- a/src/MuchAdo.Npgsql/NpgsqlDbConnector.cs
+++ b/src/MuchAdo.Npgsql/NpgsqlDbConnector.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.Data.Common;
 using Npgsql;
 
 namespace MuchAdo.Npgsql;
@@ -9,16 +8,14 @@ namespace MuchAdo.Npgsql;
 /// </summary>
 public class NpgsqlDbConnector : DbConnector
 {
-	public NpgsqlDbConnector(DbConnection connection)
+	public NpgsqlDbConnector(NpgsqlConnection connection)
 		: this(connection, NpgsqlDbConnectorSettings.Default)
 	{
 	}
 
-	public NpgsqlDbConnector(DbConnection connection, NpgsqlDbConnectorSettings settings)
+	public NpgsqlDbConnector(NpgsqlConnection connection, NpgsqlDbConnectorSettings settings)
 		: base(connection, settings)
 	{
-		if (connection is not NpgsqlConnection)
-			throw new ArgumentException("The connection must be a NpgsqlConnection.", nameof(connection));
 	}
 
 	public new NpgsqlConnection Connection => (NpgsqlConnection) base.Connection;

--- a/src/MuchAdo.SqlServer/SqlServerDbConnector.cs
+++ b/src/MuchAdo.SqlServer/SqlServerDbConnector.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.Data.Common;
 using Microsoft.Data.SqlClient;
 
 namespace MuchAdo.SqlServer;
@@ -9,16 +8,14 @@ namespace MuchAdo.SqlServer;
 /// </summary>
 public class SqlServerDbConnector : DbConnector
 {
-	public SqlServerDbConnector(DbConnection connection)
+	public SqlServerDbConnector(SqlConnection connection)
 		: this(connection, SqlServerDbConnectorSettings.Default)
 	{
 	}
 
-	public SqlServerDbConnector(DbConnection connection, SqlServerDbConnectorSettings settings)
+	public SqlServerDbConnector(SqlConnection connection, SqlServerDbConnectorSettings settings)
 		: base(connection, settings)
 	{
-		if (connection is not SqlConnection)
-			throw new ArgumentException("The connection must be a SqlConnection.", nameof(connection));
 	}
 
 	public new SqlConnection Connection => (SqlConnection) base.Connection;

--- a/src/MuchAdo.Sqlite/SqliteDbConnector.cs
+++ b/src/MuchAdo.Sqlite/SqliteDbConnector.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.Data.Common;
 using Microsoft.Data.Sqlite;
 
 namespace MuchAdo.Sqlite;
@@ -9,16 +8,14 @@ namespace MuchAdo.Sqlite;
 /// </summary>
 public class SqliteDbConnector : DbConnector
 {
-	public SqliteDbConnector(DbConnection connection)
+	public SqliteDbConnector(SqliteConnection connection)
 		: this(connection, SqliteDbConnectorSettings.Default)
 	{
 	}
 
-	public SqliteDbConnector(DbConnection connection, SqliteDbConnectorSettings settings)
+	public SqliteDbConnector(SqliteConnection connection, SqliteDbConnectorSettings settings)
 		: base(connection, settings)
 	{
-		if (connection is not SqliteConnection)
-			throw new ArgumentException("The connection must be a SqliteConnection.", nameof(connection));
 	}
 
 	public new SqliteConnection Connection => (SqliteConnection) base.Connection;


### PR DESCRIPTION
This PR tightens the platform-specific connector APIs so they require their provider-specific connection types instead of DbConnection.

It also bumps the package version to 1.2.0. Although this is a breaking change, the release is intentionally kept as a minor version bump because the impact is limited.

Validation: dotnet build MuchAdo.slnx