### PR TITLE
Validate unnamed parameter strategy inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,17 @@
 
 ## Bumping the Package Version
 
-When bumping the package version, check git history for the last change to `<VersionPrefix>` to determine what behavior has changed since the last package version bump. Use that information to decide whether to use a major, minor, or patch bump.
+When bumping the package version, complete this history review before editing any version or release notes files:
+
+* Find the last commit that changed `<VersionPrefix>`.
+* Enumerate every commit since that commit, for example with `git log --reverse --oneline <version-commit>..HEAD`.
+* Enumerate every changed file since that commit, for example with `git diff --stat <version-commit>..HEAD` and `git diff --name-status <version-commit>..HEAD`.
+* Inspect the relevant diffs and tests for those commits.
+* Summarize the behavior changes that have happened since the last package version bump.
+
+Use that complete history review to decide whether to use a major, minor, or patch bump.
+
+`ReleaseNotes.md` must account for every release-relevant behavior change since the previous `<VersionPrefix>` change, not just the change from the current branch. Do not omit fixes that already landed on the base branch after the previous package version bump.
 
 Update `Directory.Build.props`, but set `<PackageValidationBaselineVersion>` to the current value of `<VersionPrefix>` before bumping `<VersionPrefix>`. Then update `ReleaseNotes.md`.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <PackageValidationBaselineVersion>1.2.0</PackageValidationBaselineVersion>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.2.1
+
+* Validate unnamed parameter strategy strings so null and empty values fail at configuration time instead of producing invalid or misleading SQL.
+
 ## 1.2.0
 
 * Change platform-specific connector constructors to require their provider-specific connection types instead of `DbConnection`. (This is a breaking change, but we're sticking with a minor version bump due to limited impact.)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,12 @@
 
 ## 1.2.1
 
+* Fix construction of DTO mappers for self-referential and mutually referential DTO types, allowing selected non-circular properties to map successfully and reporting selected circular properties with a meaningful exception.
+* Stabilize repeated rendering of SQL sources created from deferred enumerables.
+* Fix DTO mapping across multiple result sets with different field orders.
+* Fix nullable multi-field mapping for nullable value tuples and all-null rows.
+* Fix field-count validation for variable-length `ValueTuple` mappings.
+* Fix double disposal of pooled connectors so disposing twice doesn't return the same connector to the pool twice.
 * Validate unnamed parameter strategy strings so null and empty values fail at configuration time instead of producing invalid or misleading SQL.
 
 ## 1.2.0

--- a/src/MuchAdo/SqlUnnamedParameterStrategy.cs
+++ b/src/MuchAdo/SqlUnnamedParameterStrategy.cs
@@ -8,20 +8,41 @@ public sealed class SqlUnnamedParameterStrategy
 	/// <summary>
 	/// Uses named parameters with the specified prefix.
 	/// </summary>
-	public static SqlUnnamedParameterStrategy Named(string namePrefix) =>
-		new() { NamedParameterNamePrefix = namePrefix };
+	public static SqlUnnamedParameterStrategy Named(string namePrefix)
+	{
+		if (namePrefix is null)
+			throw new ArgumentNullException(nameof(namePrefix));
+		if (namePrefix.Length == 0)
+			throw new ArgumentException("Name prefix cannot be empty.", nameof(namePrefix));
+
+		return new() { NamedParameterNamePrefix = namePrefix };
+	}
 
 	/// <summary>
 	/// Uses numbered parameters with the specified prefix.
 	/// </summary>
-	public static SqlUnnamedParameterStrategy Numbered(string placeholderPrefix) =>
-		new() { NumberedParameterPlaceholderPrefix = placeholderPrefix };
+	public static SqlUnnamedParameterStrategy Numbered(string placeholderPrefix)
+	{
+		if (placeholderPrefix is null)
+			throw new ArgumentNullException(nameof(placeholderPrefix));
+		if (placeholderPrefix.Length == 0)
+			throw new ArgumentException("Placeholder prefix cannot be empty.", nameof(placeholderPrefix));
+
+		return new() { NumberedParameterPlaceholderPrefix = placeholderPrefix };
+	}
 
 	/// <summary>
 	/// Uses unnumbered parameters with the specified placeholder.
 	/// </summary>
-	public static SqlUnnamedParameterStrategy Unnumbered(string placeholder) =>
-		new() { UnnumberedParameterPlaceholder = placeholder };
+	public static SqlUnnamedParameterStrategy Unnumbered(string placeholder)
+	{
+		if (placeholder is null)
+			throw new ArgumentNullException(nameof(placeholder));
+		if (placeholder.Length == 0)
+			throw new ArgumentException("Placeholder cannot be empty.", nameof(placeholder));
+
+		return new() { UnnumberedParameterPlaceholder = placeholder };
+	}
 
 	internal string? NamedParameterNamePrefix { get; init; }
 

--- a/tests/MuchAdo.Tests/SqlSyntaxTests.cs
+++ b/tests/MuchAdo.Tests/SqlSyntaxTests.cs
@@ -40,6 +40,36 @@ internal sealed class SqlSyntaxTests
 	}
 
 	[Test]
+	public void NamedUnnamedParameterStrategyValidatesNamePrefix()
+	{
+		Invoking(() => SqlUnnamedParameterStrategy.Named(null!)).Should().Throw<ArgumentNullException>().WithParameterName("namePrefix");
+		Invoking(() => SqlUnnamedParameterStrategy.Named(""))
+			.Should().Throw<ArgumentException>()
+			.WithParameterName("namePrefix")
+			.WithMessage("Name prefix cannot be empty.*");
+	}
+
+	[Test]
+	public void NumberedUnnamedParameterStrategyValidatesPlaceholderPrefix()
+	{
+		Invoking(() => SqlUnnamedParameterStrategy.Numbered(null!)).Should().Throw<ArgumentNullException>().WithParameterName("placeholderPrefix");
+		Invoking(() => SqlUnnamedParameterStrategy.Numbered(""))
+			.Should().Throw<ArgumentException>()
+			.WithParameterName("placeholderPrefix")
+			.WithMessage("Placeholder prefix cannot be empty.*");
+	}
+
+	[Test]
+	public void UnnumberedUnnamedParameterStrategyValidatesPlaceholder()
+	{
+		Invoking(() => SqlUnnamedParameterStrategy.Unnumbered(null!)).Should().Throw<ArgumentNullException>().WithParameterName("placeholder");
+		Invoking(() => SqlUnnamedParameterStrategy.Unnumbered(""))
+			.Should().Throw<ArgumentException>()
+			.WithParameterName("placeholder")
+			.WithMessage("Placeholder cannot be empty.*");
+	}
+
+	[Test]
 	public void NamedParamSql()
 	{
 		var (text, parameters) = Render(Sql.NamedParam("abccb", "xyzzy"));


### PR DESCRIPTION
## Summary
- Validate null and empty strings in SqlUnnamedParameterStrategy factory methods.
- Bump the package version to 1.2.1 and expand release notes for all release-relevant fixes since 1.2.0.
- Clarify AGENTS.md so future version bumps must enumerate commits, changed files, diffs, and tests since the previous VersionPrefix change before editing release notes.

## Release notes now cover
- Circular DTO mapper construction fixes.
- Stable repeated rendering of deferred SqlSource enumerables.
- DTO mapping across multiple result sets with different field orders.
- Nullable multi-field and ValueTuple validation fixes.
- Pooled connector double-disposal behavior.
- Unnamed parameter strategy input validation.

## Tests
- SqlSyntaxTests.cs passed: 76 tests.